### PR TITLE
Update Actions to @v4 because @v3 is deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     container: pablomk7/luma3dsbuildtools
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: safedir
       run: git config --system --add safe.directory /__w/Luma3DS/Luma3DS
     - name: Build
       run: make -j$(nproc --all)
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Polari3DS-nightly
         path: boot.firm


### PR DESCRIPTION
Just leaving this to start when you are ready to, because it is needed to make final version or nightly build.
No worries, is just a to start thing, take the time you need.